### PR TITLE
Update github runner image to ubuntu 24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ name: Continuous integration
 
 jobs:
   ci-linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
20.04 is no longer supported, see https://github.com/actions/runner-images/issues/11101